### PR TITLE
📝 `TOBIAS`: Sprout README as Contributor-Facing Product Marketing

### DIFF
--- a/app/furniture/tobias/README.md
+++ b/app/furniture/tobias/README.md
@@ -16,8 +16,4 @@ What if restaurants and grocers lowered prices because food workers receive a su
 What if we all received a little-bit of cash every month thanks to the California Residents Basic Income Program?
 
 <!-- Fix: Community-Operated, Automated Basic Income -->
-TOBIAS, the TOpical Basic Income Administration System automates administering a basic income trust for industries, communities, regions, and organizations.
-
-TOBIAS combines democratic stewardship, financial automation, and trust fund management to collect, invest and distribute wealth as a community.
-
-Whether administering a basic income fund for a region, industry, organization, or community; TOBIAS simplifies record-keeping, drives investment, and streamlines participant payments.
+TOBIAS combines democratic stewardship, financial automation, and trust fund management to reduce financial stress of people around us. It simplifies record-keeping, facilitates decision-making, and streamlines payments when administering a basic income fund for a region, industry, organization, or community.

--- a/app/furniture/tobias/README.md
+++ b/app/furniture/tobias/README.md
@@ -1,0 +1,23 @@
+# [TOBIAS, the TOpical Basic Income Administration Service](https://github.com/zspencer/convene/issues/1)
+<!-- Pain: People are hungry and unhoused, yo. -->
+
+Many people have insufficient free cashflow to cover reliable, healthy, and safe shelter, food, health care, and education.
+
+So much energy is spent worrying about affording to live in a place that suits us, to eat food we enjoy, to receive care when we are hurting or infirm, or to develop ourselves further to the people we want to be.
+
+
+<!-- Dream: What if people didn't have to worry as much about money? -->
+What if people didn't have to invest so much of their daily energy on how to access reliable, healthy, and safe shelter, food, health care, and education?
+
+What if education workers could spend more time focusing on teaching because they had access to additional income through a California Education Workers Basic Income Fund, their Teachers Union, or the American Association for Montessori Educators?
+
+What if restaurants and grocers lowered prices because food workers receive a supplemental wage through the County Food Workers Living Wage Trust?
+
+What if we all received a little-bit of cash every month thanks to the California Residents Basic Income Program?
+
+<!-- Fix: Community-Operated, Automated Basic Income -->
+TOBIAS, the TOpical Basic Income Administration System automates administering a basic income trust for industries, communities, regions, and organizations.
+
+TOBIAS combines democratic stewardship, financial automation, and trust fund management to collect, invest and distribute wealth as a community.
+
+Whether administering a basic income fund for a region, industry, organization, or community; TOBIAS simplifies record-keeping, drives investment, and streamlines participant payments.


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/709
- https://github.com/zspencer/convene/issues/1

This is an attempt at using a README as a form of product-design documentation.

It follows the Pain-Dream-Fix recipe for marketing copy, with an emphasis on the code's *purpose*. By exposing the purpose of the code; new contributors (or contributors that have been away for a bit) have a way of grounding themselves in the product-thinking behind the project itself.

That said, good README's have additional context beyond the purpose, such as:

- A Data Model, which exposes a high-level view of the interactions between entities within the system we are building.
- Setup instructions, such as guidance for how to populate an initial database or a reference to additional software to install.

But for now we don't have either of those things; and I wanted to do some Product-based House Keeping, such as creating Fauxsonas and Use Cases before diving into Engineering.