### PR TITLE
🥗 `Tobias`: Issuing indivisible `Payout#amount` rounds each `Payment#amount` down

### DIFF
--- a/spec/tobias/payout_spec.rb
+++ b/spec/tobias/payout_spec.rb
@@ -15,5 +15,19 @@ RSpec.describe Tobias::Payout do
         expect(beneficiary.payments).to exist(amount_cents: 15_00)
       end
     end
+
+    context "when the Payout#amount does not divide evenly" do
+      it "rounds down so that it can" do
+        payout = create(:tobias_payout, amount_cents: 3_33)
+
+        beneficiaries = create_list(:tobias_beneficiary, 2, trust: payout.trust)
+
+        payout.issue
+
+        beneficiaries.each do |beneficiary|
+          expect(beneficiary.payments).to exist(amount_cents: 1_66)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I wasn't exactly sure what would happen, so I took the time to figure it out.

Apparently, the [`money-rails` gem] we use defaults to rounding down, which is the safer thing to do.

[`money-rails` gem]: https://github.com/RubyMoney/money-rails