### PR TITLE
🥗 `Tobias`: Test issuing `Payouts` twice doesn't create more `Payments`

### DIFF
--- a/app/furniture/tobias/payout.rb
+++ b/app/furniture/tobias/payout.rb
@@ -9,6 +9,8 @@ class Tobias
     monetize :amount_cents
 
     def issue
+      return if payments.present?
+
       per_beneficiary_amount = (amount / beneficiaries.count)
       beneficiaries.each do |beneficiary|
         payments.create_with(amount: per_beneficiary_amount).find_or_create_by(beneficiary_id: beneficiary.id)

--- a/spec/tobias/payout_spec.rb
+++ b/spec/tobias/payout_spec.rb
@@ -29,5 +29,17 @@ RSpec.describe Tobias::Payout do
         end
       end
     end
+
+    context "when running twice" do
+      it "does not issue multiple payouts" do
+        payout = create(:tobias_payout, amount_cents: 100_00)
+
+        create_list(:tobias_beneficiary, 2, trust: payout.trust)
+
+        payout.issue
+
+        expect { payout.issue }.not_to(change(payout.payments, :count))
+      end
+    end
   end
 end

--- a/spec/tobias/payout_spec.rb
+++ b/spec/tobias/payout_spec.rb
@@ -31,12 +31,18 @@ RSpec.describe Tobias::Payout do
     end
 
     context "when running twice" do
-      it "does not issue multiple payouts" do
+      it "does not issue multiple payouts, even when beneficiaries are added" do
         payout = create(:tobias_payout, amount_cents: 100_00)
 
         create_list(:tobias_beneficiary, 2, trust: payout.trust)
 
         payout.issue
+
+        create(:tobias_beneficiary, trust: payout.trust)
+
+        # ActiveRecord appears to be caching the `payout.beneficiaries` results
+        # Reload busts that cache.
+        payout.reload
 
         expect { payout.issue }.not_to(change(payout.payments, :count))
       end


### PR DESCRIPTION
There were two open questions:

- What happens if we run it twice without changes?
- What happens if `Beneficiaries` change between runs?

In the first case, everything is fine! (though it may have gone sideways were we to say, change the `Payout#amount`)
In the second case, things were not create; because it would have created a new `Payment` at a different `Payment#amount` for the new beneficiary, even though the entire `Payout#amount` had already been distributed!

Oops.